### PR TITLE
fix: Infinity in width calculation when maxValue is 0

### DIFF
--- a/src/components/layout/progressBar/ProgressBar.tsx
+++ b/src/components/layout/progressBar/ProgressBar.tsx
@@ -43,7 +43,7 @@ export function ProgressBar({
 		}
 	}, [isLoading, currentValue, floatRef])
 
-	const percent = (currentValue / maxValue) * 100
+	const percent = maxValue > 0 ? (currentValue / maxValue) * 100 : 0
 
 	const progressValueBig = isLoading ? (
 		<SkeletonLoader width={128} height={27.5} />


### PR DESCRIPTION
i’ve fixed an issue where when `maxValue` is equal to 0, the result of the calculation would be `Infinity`, causing the CSS `width` to be set to `Infinity%`. this led to unexpected behavior in the layout.

now, if `maxValue` is 0, the width will be set to `0%` instead, which is safer.

### Code:
```tsx
const percent = maxValue > 0 ? (currentValue / maxValue) * 100 : 0;
```